### PR TITLE
Updated driver to use Java17 in pom.xml and Dockerfile base image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,14 +41,15 @@
         <helm.repo.snapshots.url>${helm.repo.addr}/accanto/snapshots</helm.repo.snapshots.url>
         <helm.repo.url>${helm.repo.addr}/accanto/stable</helm.repo.url>
         <httpclient.version>4.5.13</httpclient.version>
-        <jacoco-maven-plugin.version>0.8.4</jacoco-maven-plugin.version>
-        <java.version>11</java.version>
+        <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
+        <java.version>17</java.version>
         <kiwigrid.version>2.5</kiwigrid.version>
         <logstash-logback-encoder.version>7.2</logstash-logback-encoder.version>
         <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
         <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <nashorn-core.version>15.4</nashorn-core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.testresult.directory>${project.build.directory}/test-results</project.testresult.directory>
@@ -86,6 +87,11 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>${httpclient.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.nashorn</groupId>
+            <artifactId>nashorn-core</artifactId>
+            <version>${nashorn-core.version}</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -159,6 +165,12 @@
             <artifactId>spring-kafka-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
+            <version>5.7.5</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
@@ -168,12 +180,6 @@
             <groupId>org.springframework.security.oauth</groupId>
             <artifactId>spring-security-oauth2</artifactId>
             <version>2.5.2.RELEASE</version>
-        </dependency>
-        
-         <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-core</artifactId>
-            <version>5.7.5</version>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>

--- a/src/main/resources/docker/Dockerfile
+++ b/src/main/resources/docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG JDK_IMAGE=icr.io/appcafe/ibm-semeru-runtimes
-ARG JDK_VERSION=certified-11-jre-ubi
+ARG JDK_VERSION=certified-17-jre-ubi
 FROM ${JDK_IMAGE}:${JDK_VERSION}
 ENV JVM_OPTIONS=-Xmx256m
 COPY *.sh /data/


### PR DESCRIPTION
# Pull Request Review

## Checklist

- [x] **Issue** : https://github.com/IBM/sol005-lifecycle-driver/issues/121
- [x] **List of related PRs** : N.A.
- [x] **Project builds without any errors** Yes
- [x] **Unit Tests** : All passed
- [x] **Ran manual functional “smoke” test (does product as a whole still work?)** Yes
- [x] **User Story meets the acceptance criteria and passes** Yes
- [x]  **Description of the changes**:  
1. Updated pom.xml to use Java17. 
2. Updated Dockerfile to use java17 image 
3. Added open source nashorn dependency in pom.xml as it is removed from Java15 onwards
4. Updated dependent library version of Jacobo and Spotify's docker-maven-plugin versions.